### PR TITLE
Fix wiki URL.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
   	</pluginManagement>
   </build>
   <name>Script SCM Plug-In</name>
-  <url>http://wiki.jenkins-ci.org/display/Jenkins/script-scm</url>
+  <url>https://wiki.jenkins-ci.org/display/JENKINS/Script+SCM+Plugin</url>
   <developers>
   <developer>
   	<id>vimil</id>


### PR DESCRIPTION
There were two "script-scm" pages on the Jenkins wiki, and the Jenkins Update Centre points to this properly-named URL, so the POM should point to the same place.

Note that the old "script-scm" URL no longer exists, but it currently _appears_ to exist due to a [caching bug](https://issues.jenkins-ci.org/browse/INFRA-301) in the wiki.
